### PR TITLE
Utiliser un énumérateur pour énumérer les pages du garde-fou

### DIFF
--- a/AFTER-G SmartNet Browser/BrowserForm.vb
+++ b/AFTER-G SmartNet Browser/BrowserForm.vb
@@ -1099,9 +1099,10 @@ Public Class BrowserForm
             Case MessageBar.MessageBarAction.OpenPopup
                 AddTab(msgBar.link)
             Case MessageBar.MessageBarAction.RestorePreviousSession
-                For Each page As String In My.Settings.LastSessionListOfTabs
-                    AddTab(page)
-                Next
+                Dim enumerator = My.Settings.LastSessionListOfTabs.GetEnumerator
+                While enumerator.MoveNext()
+                    AddTab(enumerator.Current)
+                End While
                 My.Settings.CorrectlyClosed = False
             Case MessageBar.MessageBarAction.OpenExceptionForm
                 ExceptionForm.SetException(msgBar.exception)


### PR DESCRIPTION
Permet la résolution du bug #4 