### PR TITLE
Bugfix 9 : Ne pas interroger le serveur lorsqu'aucune connexion n'est disponible

### DIFF
--- a/AFTER-G SmartNet Browser/AppSyncAgent.vb
+++ b/AFTER-G SmartNet Browser/AppSyncAgent.vb
@@ -2,6 +2,8 @@
 Imports System.Web
 Imports System.Text
 Imports Newtonsoft.Json
+Imports System.Windows.Forms.VisualStyles.VisualStyleElement.StartPanel
+Imports System.IO
 
 ''' <summary>
 ''' Agent de connexion de SmartNet AppSync
@@ -161,8 +163,18 @@ Public Class AppSyncAgent
     ''' </summary>
     ''' <returns></returns>
     Public Shared Function GetUserName() As String
-        Dim userDetails As UserDetails = AppSyncAgent.GetUserDetails()
-        Return userDetails.prenomUtilisateur + " " + userDetails.nomUtilisateur
+        Dim LocalFilePath = My.Computer.FileSystem.SpecialDirectories.CurrentUserApplicationData.ToString() + "\appsyncusername.txt"
+        Try
+            Dim userDetails As UserDetails = AppSyncAgent.GetUserDetails()
+            File.WriteAllText(My.Computer.FileSystem.SpecialDirectories.CurrentUserApplicationData.ToString() + "\appsyncusername.txt", userDetails.prenomUtilisateur + " " + userDetails.nomUtilisateur)
+            Return userDetails.prenomUtilisateur + " " + userDetails.nomUtilisateur
+        Catch ex As Exception
+            If (File.Exists(LocalFilePath)) Then
+                Return File.ReadAllText(LocalFilePath)
+            Else
+                Return ""
+            End If
+        End Try
     End Function
 
     ''' <summary>
@@ -170,17 +182,24 @@ Public Class AppSyncAgent
     ''' </summary>
     ''' <returns></returns>
     Public Shared Function GetUserProfilePicture() As Bitmap
-        Dim imgDistantPath As String = AppSyncAgent.GetUserDetails().imageProfilClient
-        Dim imgLocalPath As String = My.Computer.FileSystem.SpecialDirectories.CurrentUserApplicationData.ToString() + "\appsyncprofilepic" + imgDistantPath.Substring(imgDistantPath.LastIndexOf("."))
+        Dim LocalFilePath As String = My.Computer.FileSystem.SpecialDirectories.CurrentUserApplicationData.ToString() + "\appsyncprofilepic.dat"
+
         Try
-            If System.IO.File.Exists(imgLocalPath) Then
-                System.IO.File.Delete(imgLocalPath)
+            Dim imgDistantPath As String = AppSyncAgent.GetUserDetails().imageProfilClient
+            If System.IO.File.Exists(LocalFilePath) Then
+                System.IO.File.Delete(LocalFilePath)
             End If
+
             Dim telechargeur As New WebClient()
-            telechargeur.DownloadFile(imgDistantPath, imgLocalPath)
+            telechargeur.DownloadFile(imgDistantPath, LocalFilePath)
         Catch ex As Exception
         End Try
-        Return New Bitmap(imgLocalPath)
+
+        If File.Exists(LocalFilePath) Then
+            Return New Bitmap(LocalFilePath)
+        Else
+            Return My.Resources.Person
+        End If
     End Function
 
     ''' <summary>

--- a/AFTER-G SmartNet Browser/AppSyncAgent.vb
+++ b/AFTER-G SmartNet Browser/AppSyncAgent.vb
@@ -721,6 +721,8 @@ Public Class AppSyncAgent
     ''' <returns></returns>
     Public Shared Function IsDeviceRegistered() As Boolean
         If My.Settings.AppSyncDeviceNumber <> "" Then
+            If Not NetworkChecker.IsInternetAvailable Then Return True
+
             Dim details As Connection = AppSyncAgent.GetDeviceDetails()
             If details.idUtilisateur <> GetUserID() Then
                 Throw New AppSyncException("Le numéro de session enregistré n'est pas associé à l'utilisateur actuellement connecté.")

--- a/AFTER-G SmartNet Browser/BrowserForm.vb
+++ b/AFTER-G SmartNet Browser/BrowserForm.vb
@@ -310,13 +310,11 @@ Public Class BrowserForm
 
         Try
             If AppSyncAgent.IsDeviceRegistered() Then
+                SeConnecterÀAppSyncToolStripMenuItem.Text = AppSyncAgent.GetUserName()
+                SeConnecterÀAppSyncToolStripMenuItem.Image = AppSyncAgent.GetUserProfilePicture()
+
                 If Not NetworkChecker.IsInternetAvailable Then
-                    SeConnecterÀAppSyncToolStripMenuItem.Text = "Déconnecté d'Internet"
-                    SeConnecterÀAppSyncToolStripMenuItem.Image = My.Resources.Person
                     SeConnecterÀAppSyncToolStripMenuItem.Enabled = False
-                Else
-                    SeConnecterÀAppSyncToolStripMenuItem.Text = AppSyncAgent.GetUserName()
-                    SeConnecterÀAppSyncToolStripMenuItem.Image = AppSyncAgent.GetUserProfilePicture()
                 End If
             Else
                 If My.Settings.AppSyncDeviceNumber <> "" Then

--- a/AFTER-G SmartNet Browser/BrowserForm.vb
+++ b/AFTER-G SmartNet Browser/BrowserForm.vb
@@ -310,8 +310,14 @@ Public Class BrowserForm
 
         Try
             If AppSyncAgent.IsDeviceRegistered() Then
-                SeConnecterÀAppSyncToolStripMenuItem.Text = AppSyncAgent.GetUserName()
-                SeConnecterÀAppSyncToolStripMenuItem.Image = AppSyncAgent.GetUserProfilePicture()
+                If Not NetworkChecker.IsInternetAvailable Then
+                    SeConnecterÀAppSyncToolStripMenuItem.Text = "Déconnecté d'Internet"
+                    SeConnecterÀAppSyncToolStripMenuItem.Image = My.Resources.Person
+                    SeConnecterÀAppSyncToolStripMenuItem.Enabled = False
+                Else
+                    SeConnecterÀAppSyncToolStripMenuItem.Text = AppSyncAgent.GetUserName()
+                    SeConnecterÀAppSyncToolStripMenuItem.Image = AppSyncAgent.GetUserProfilePicture()
+                End If
             Else
                 If My.Settings.AppSyncDeviceNumber <> "" Then
                     msgBar = New MessageBar(MessageBar.MessageBarLevel.Info, "Cet appareil a été déconnecté de SmartNet AppSync.", MessageBar.MessageBarAction.DisplayAppSyncLogin, "Se reconnecter...")

--- a/AFTER-G SmartNet Browser/NetworkChecker.vb
+++ b/AFTER-G SmartNet Browser/NetworkChecker.vb
@@ -1,0 +1,27 @@
+﻿Public Class NetworkChecker
+    ''' <summary>
+    ''' Envoie une requête Ping à lesmajesticiels.org.
+    ''' </summary>
+    ''' <returns>True en cas de réussite, False en cas d'échec</returns>
+    Public Shared Function IsInternetAvailable() As Boolean
+        If Not My.Computer.Network.IsAvailable Then Return False
+
+        Dim rv As Boolean = False
+        Dim ping As New Net.NetworkInformation.Ping
+        Dim reply As Net.NetworkInformation.PingReply
+        Dim options As New Net.NetworkInformation.PingOptions
+
+        Try
+            Dim buf(4) As Byte
+            reply = ping.Send("www.lesmajesticiels.org", 1000, buf, options)
+
+            If reply.Status = Net.NetworkInformation.IPStatus.TtlExpired Then
+                Return True
+            End If
+        Catch ex As Exception
+            Return False
+        End Try
+
+        Return True
+    End Function
+End Class

--- a/AFTER-G SmartNet Browser/SettingsForm.vb
+++ b/AFTER-G SmartNet Browser/SettingsForm.vb
@@ -1,6 +1,7 @@
 ﻿Imports System.ComponentModel
 Imports System.IO.File
 Imports System.Net
+Imports Microsoft.VisualBasic.Devices
 Imports Microsoft.Win32
 
 Public Class SettingsForm
@@ -24,6 +25,7 @@ Public Class SettingsForm
     End Function
 
     Private Async Function AppSyncSendConfigAsync() As Task(Of Boolean)
+        If Not NetworkChecker.IsInternetAvailable Then Return False
         Try
             Return Await AppSyncAgent.SendConfig()
         Catch ex As Exception
@@ -155,6 +157,17 @@ Public Class SettingsForm
             ButtonManageAccount.Visible = False
             ButtonLoginLogout.Text = "Se connecter..."
             ButtonLoginLogout.Enabled = True
+            LabelUsername.Text = "Déconnecté.e"
+            PictureBoxUserProfilePic.Image = My.Resources.Person
+            GroupBoxAppSyncDevice.Visible = False
+            ButtonChangeAppSyncDeviceName.Enabled = False
+            ButtonSyncNow.Enabled = False
+            ButtonSyncNow.Visible = False
+        ElseIf Not NetworkChecker.IsInternetAvailable Then
+            ButtonManageAccount.Enabled = False
+            ButtonManageAccount.Visible = False
+            ButtonLoginLogout.Text = "Internet indisponible"
+            ButtonLoginLogout.Enabled = False
             LabelUsername.Text = "Déconnecté.e"
             PictureBoxUserProfilePic.Image = My.Resources.Person
             GroupBoxAppSyncDevice.Visible = False

--- a/AFTER-G SmartNet Browser/SettingsForm.vb
+++ b/AFTER-G SmartNet Browser/SettingsForm.vb
@@ -163,31 +163,34 @@ Public Class SettingsForm
             ButtonChangeAppSyncDeviceName.Enabled = False
             ButtonSyncNow.Enabled = False
             ButtonSyncNow.Visible = False
-        ElseIf Not NetworkChecker.IsInternetAvailable Then
-            ButtonManageAccount.Enabled = False
-            ButtonManageAccount.Visible = False
-            ButtonLoginLogout.Text = "Internet indisponible"
-            ButtonLoginLogout.Enabled = False
-            LabelUsername.Text = "Déconnecté.e"
-            PictureBoxUserProfilePic.Image = My.Resources.Person
-            GroupBoxAppSyncDevice.Visible = False
-            ButtonChangeAppSyncDeviceName.Enabled = False
-            ButtonSyncNow.Enabled = False
-            ButtonSyncNow.Visible = False
         Else
             Try
-                ButtonManageAccount.Enabled = True
-                ButtonManageAccount.Visible = True
-                ButtonLoginLogout.Text = "Se déconnecter..."
-                ButtonLoginLogout.Enabled = True
-                LabelUsername.Text = AppSyncAgent.GetUserName()
-                PictureBoxUserProfilePic.Image = New Bitmap(AppSyncAgent.GetUserProfilePicture(), 54, 54)
-                GroupBoxAppSyncDevice.Visible = True
-                TextBoxAppSyncDeviceName.Text = AppSyncAgent.GetDeviceName()
-                ButtonChangeAppSyncDeviceName.Enabled = False
-                ButtonSyncNow.Visible = True
-                ButtonSyncNow.Enabled = True
-            Catch ex As AppSyncException
+                If Not NetworkChecker.IsInternetAvailable Then
+                    ButtonManageAccount.Enabled = False
+                    ButtonManageAccount.Visible = True
+                    ButtonLoginLogout.Text = "Se déconnecter..."
+                    ButtonLoginLogout.Enabled = False
+                    LabelUsername.Text = AppSyncAgent.GetUserName()
+                    PictureBoxUserProfilePic.Image = New Bitmap(AppSyncAgent.GetUserProfilePicture(), 54, 54)
+                    GroupBoxAppSyncDevice.Visible = True
+                    TextBoxAppSyncDeviceName.Text = ""
+                    ButtonChangeAppSyncDeviceName.Enabled = False
+                    ButtonSyncNow.Visible = True
+                    ButtonSyncNow.Enabled = False
+                Else
+                    ButtonManageAccount.Enabled = True
+                    ButtonManageAccount.Visible = True
+                    ButtonLoginLogout.Text = "Se déconnecter..."
+                    ButtonLoginLogout.Enabled = True
+                    LabelUsername.Text = AppSyncAgent.GetUserName()
+                    PictureBoxUserProfilePic.Image = New Bitmap(AppSyncAgent.GetUserProfilePicture(), 54, 54)
+                    GroupBoxAppSyncDevice.Visible = True
+                    TextBoxAppSyncDeviceName.Text = AppSyncAgent.GetDeviceName()
+                    ButtonChangeAppSyncDeviceName.Enabled = False
+                    ButtonSyncNow.Visible = True
+                    ButtonSyncNow.Enabled = True
+                End If
+            Catch ex As Exception
                 ButtonManageAccount.Enabled = False
                 ButtonManageAccount.Visible = True
                 ButtonLoginLogout.Text = "Se déconnecter..."

--- a/AFTER-G SmartNet Browser/SmartNet Browser.vbproj
+++ b/AFTER-G SmartNet Browser/SmartNet Browser.vbproj
@@ -247,6 +247,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="NetworkChecker.vb" />
     <Compile Include="NewHistoryForm.Designer.vb">
       <DependentUpon>NewHistoryForm.vb</DependentUpon>
     </Compile>


### PR DESCRIPTION
Permet à résolution du bug #9.
Ajout d'une fonction permettant de vérifier la connectivité à Internet et usage de cette fonction pour ne pas interroger AppSync à l'ouverture